### PR TITLE
docs: align documentation structure with action-container-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-[![checks](https://github.com/martoc/action-tag/actions/workflows/checks.yml/badge.svg)](https://github.com/martoc/action-tag/actions/workflows/checks.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![slack](https://img.shields.io/badge/slack-general-brightgreen.svg?logo=slack)](https://app.slack.com/messages/T8L8AAD3M/C8LBHLSVA)
 
 # action-tag
 
-[Documentation >>](./docs/index.md)
+A GitHub Action that calculates and applies semantic version tags to repositories based on commit messages. It follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification to determine version increments and supports multiple tag formats including SemVer and PEP440.
+
+## Table of Content
+
+* [Code Style](./docs/CODESTYLE.md)
+* [Usage](./docs/USAGE.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,0 @@
-Calculates a new checking on the commit logs, uses the commit message to calculate the new version number. The version number is calculated based on the commit message, the commit message should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
-
-# Table of Content
-
-* [Code Style](./CODESTYLE.md)
-* [Usage](./USAGE.md)
-
-


### PR DESCRIPTION
## Summary

- Update README.md to include project description and Table of Content section
- Remove docs/index.md as content now lives directly in README.md
- Align documentation structure with action-container-build repository

## Test plan

- [ ] Verify README.md displays correctly on GitHub
- [ ] Verify links to docs/CODESTYLE.md and docs/USAGE.md work correctly