### PR TITLE
Allow tag artifact overwrite

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,7 @@ runs:
       with:
         name: tags
         path: ~/tags
+        overwrite: true
       if: ${{ inputs.execute  == 'tag' }}
     - uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
This change allows combining multiple workflows that each are using the tag action in the same workflow.