### PR TITLE
feat: add append-build-id input to suffix tag with GitHub run ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A GitHub Action that calculates and applies semantic version tags to repositorie
 | `skip-push` | Skip pushing tags to remote | No | `false` |
 | `execute` | Action to perform: `tag` or `load` | No | `tag` |
 | `format` | Tag format: `semver` or `PEP440` | No | `semver` |
+| `append-build-id` | Append the GitHub Actions run ID as a build identifier (e.g. `1.2.3-build.123456789`). Floating major/minor tags are not created when enabled. | No | `false` |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,13 @@ inputs:
     description: "The format of the tag"
     required: false
     default: "semver"
+  append-build-id:
+    description: |
+      Append the GitHub Actions run ID as a build identifier to the
+      version (e.g. 1.2.3-build.123456789). When enabled, floating major
+      and minor tags are not created.
+    required: false
+    default: "false"
 
 outputs:
   version:
@@ -55,21 +62,38 @@ runs:
           TAG_NAME="v$TAG_VERSION"
         else
           TAG_SHA=$GITHUB_SHA
-          OUTPUT=$(docker run -w /workdir -v $PWD:/workdir martoc/semver:1.5.5 calculate --path /workdir --add-floating-tags)
-          TAG_VERSION=$(echo $OUTPUT | jq -r '.next_version')
-          TAG_FLOATING_VERSION_MAJOR=$(echo $OUTPUT | jq -r '.floating_version_major')
-          TAG_FLOATING_VERSION_MINOR=$(echo $OUTPUT | jq -r '.floating_version_minor')
+          SEMVER_IMAGE="martoc/semver:1.5.5"
+          if [ "${{ inputs.append-build-id }}" == "true" ]; then
+            SEMVER_FLAGS="--disable-tagging"
+          else
+            SEMVER_FLAGS="--add-floating-tags"
+          fi
+          OUTPUT=$(docker run -w /workdir -v $PWD:/workdir $SEMVER_IMAGE calculate --path /workdir $SEMVER_FLAGS)
+          if [ "${{ inputs.append-build-id }}" == "true" ]; then
+            TAG_VERSION=$(echo $OUTPUT | jq -r '.next_version')
+            TAG_VERSION="${TAG_VERSION}-build.${GITHUB_RUN_ID}"
+            TAG_NAME="v$TAG_VERSION"
+          else
+            TAG_VERSION=$(echo $OUTPUT | jq -r '.next_version')
+            TAG_FLOATING_VERSION_MAJOR=$(echo $OUTPUT | jq -r '.floating_version_major')
+            TAG_FLOATING_VERSION_MINOR=$(echo $OUTPUT | jq -r '.floating_version_minor')
 
-          TAG_NAME="v$TAG_VERSION"
-          TAG_FLOATING_MAJOR_NAME="v$TAG_FLOATING_VERSION_MAJOR"
-          TAG_FLOATING_MINOR_NAME="v$TAG_FLOATING_VERSION_MINOR"
+            TAG_NAME="v$TAG_VERSION"
+            TAG_FLOATING_MAJOR_NAME="v$TAG_FLOATING_VERSION_MAJOR"
+            TAG_FLOATING_MINOR_NAME="v$TAG_FLOATING_VERSION_MINOR"
+          fi
 
           if [ "${{ inputs.skip-push }}" == "true" ]; then
             echo "Skipping tag push because skip-push==true."
           else
             git config user.name github-actions
             git config user.email github-actions@github.com
-            git push --tags --force
+            if [ "${{ inputs.append-build-id }}" == "true" ]; then
+              git tag "$TAG_NAME" "$TAG_SHA"
+              git push origin "$TAG_NAME" --force
+            else
+              git push --tags --force
+            fi
           fi
         fi
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,11 +4,12 @@ This GitHub Action tags a repository using semantic versioning based on the comm
 
 ## Inputs
 
-| Name       | Description                                | Required | Default |
-|------------|--------------------------------------------|----------|---------|
-| skip-push  | Skip tag creation for pull requests.       | false    | false   |
-| execute    | The action to perform: `tag` or `load`.    | false    | tag     |
-| format     | The format of the tag (`semver` or `PEP440`). | false | semver  |
+| Name            | Description                                                                                                          | Required | Default |
+|-----------------|----------------------------------------------------------------------------------------------------------------------|----------|---------|
+| skip-push       | Skip tag creation for pull requests.                                                                                 | false    | false   |
+| execute         | The action to perform: `tag` or `load`.                                                                              | false    | tag     |
+| format          | The format of the tag (`semver` or `PEP440`).                                                                        | false    | semver  |
+| append-build-id | Append the GitHub Actions run ID as a build identifier (e.g. `1.2.3-build.123456789`). Disables floating major/minor tags. | false    | false   |
 
 ## Outputs
 
@@ -26,6 +27,7 @@ This GitHub Action tags a repository using semantic versioning based on the comm
 - **Otherwise:**
   - Calculates the next semantic version using the `martoc/semver:1.5.5` Docker image.
   - Creates floating tags for major and minor versions.
+  - When `append-build-id` is `true`, appends `-build.${GITHUB_RUN_ID}` to the calculated version (producing e.g. `1.2.3-build.123456789`) and only pushes that single tag (no floating major/minor tags).
   - Pushes tags unless `skip-push` is set to `true`.
 
 ### 2. Upload Tags
@@ -59,7 +61,19 @@ jobs:
           execute: tag
           format: semver
 ```
+
+### Pin a build to its GitHub Actions run
+
+```yaml
+      - name: Tag repository with build ID
+        uses: martoc/action-tag@v1
+        with:
+          append-build-id: true
+```
+
+Produces a tag like `v1.2.3-build.123456789`, where `123456789` is the GitHub Actions run ID.
+
 ## Notes
 
-The action uses the `GITHUB_RUN_ID` to append a unique build ID to the tag when using the `PEP440` format or for release candidate tags.
-Floating tags (e.g., v1, v1.2) are created for major and minor versions for easier reference.
+The action uses the `GITHUB_RUN_ID` to append a unique build ID to the tag when using the `PEP440` format, for release candidate tags, or when `append-build-id` is `true`.
+Floating tags (e.g., v1, v1.2) are created for major and minor versions for easier reference, except when `append-build-id` is `true`.


### PR DESCRIPTION
## Summary

- Add a new `append-build-id` input (default `false`) to the `action-tag` action.
- When `append-build-id: true`, the calculated semantic version is suffixed with `-build.${GITHUB_RUN_ID}`, producing tags such as `v1.2.3-build.123456789`.
- In build-id mode, semver runs with `--disable-tagging`, the build-suffixed tag is created explicitly from `TAG_SHA` and pushed on its own, and floating `vX` / `vX.Y` tags are intentionally skipped (they would churn with every run).

## Test plan

- [ ] Run the action on a non-PR push with `append-build-id: false` (default) and confirm behaviour matches current main (floating major/minor tags still pushed).
- [ ] Run the action with `append-build-id: true` on a non-PR push and confirm a single tag like `v1.2.3-build.<run_id>` is created and pushed; floating tags are not updated.
- [ ] Run with `append-build-id: true` and `skip-push: true` and confirm no tag is pushed to the remote.
- [ ] Verify YAML lint passes (`make validate`).
