### PR TITLE
fix: upgrade actions to versions supporting Node 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A GitHub Action that calculates and applies semantic version tags to repositorie
 
 ```yaml
 - name: Checkout
-  uses: actions/checkout@v4
+  uses: actions/checkout@v6
   with:
     fetch-depth: 50
     fetch-tags: true

--- a/action.yml
+++ b/action.yml
@@ -109,12 +109,12 @@ runs:
         echo "::debug::Version: $TAG_VERSION"
 
       if: ${{ inputs.execute  == 'tag' }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: tags
         path: ~/tags
       if: ${{ inputs.execute  == 'tag' }}
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: tags
       if: ${{ inputs.execute  == 'load' }}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Tag repository
         uses: martoc/action-tag@v1


### PR DESCRIPTION
## Summary

- Bump `actions/upload-artifact` v4 → v7 and `actions/download-artifact` v4 → v8 in `action.yml`
- Bump `actions/checkout` v4 → v6 in `README.md` and `docs/USAGE.md`

## Why

GitHub Actions has deprecated Node.js 20 (see [deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). From 2 June 2026, affected actions will be forced onto Node.js 24; Node.js 20 is removed from the runner on 16 September 2026. The bumped versions run on Node.js 24 by default.

## Test plan

- [ ] `make lint` passes
- [ ] CI checks pass
- [ ] Verify tag artifact upload/download still works in callers
